### PR TITLE
Add loop export backend support and tests

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+# Backend package initializer for tests and scripts.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,19 @@
-from fastapi import FastAPI, UploadFile, File, Form
+from fastapi import FastAPI, UploadFile, HTTPException, Request, Body
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
-from typing import List
-import uuid, os, json
+import uuid, os, json, wave
+from array import array
+
+
+STORAGE = os.environ.get('USM_STORAGE_DIR') or os.path.join(os.path.dirname(__file__), 'storage')
+SAMPLES = os.path.join(STORAGE, 'samples')
+PROJECTS = os.path.join(STORAGE, 'projects')
+EXPORTS = os.path.join(STORAGE, 'exports')
+os.makedirs(SAMPLES, exist_ok=True)
+os.makedirs(PROJECTS, exist_ok=True)
+os.makedirs(EXPORTS, exist_ok=True)
 
 app = FastAPI(title='USM Backend')
 
@@ -15,12 +25,6 @@ app.add_middleware(
     allow_methods=['*'],
     allow_headers=['*'],
 )
-
-STORAGE = os.path.join(os.path.dirname(__file__), 'storage')
-SAMPLES = os.path.join(STORAGE, 'samples')
-PROJECTS = os.path.join(STORAGE, 'projects')
-os.makedirs(SAMPLES, exist_ok=True)
-os.makedirs(PROJECTS, exist_ok=True)
 
 app.mount('/samples', StaticFiles(directory=SAMPLES), name='samples')
 
@@ -35,14 +39,51 @@ class Project(BaseModel):
 def health():
     return {'ok': True}
 
-@app.post('/samples/upload')
-async def upload_sample(file: UploadFile = File(...)):
-    ext = os.path.splitext(file.filename)[1] or '.bin'
+async def _process_upload(request: Request, file: UploadFile | None, payload: bytes | None):
+    if file is not None:
+        contents = await file.read()
+        original_name = file.filename or 'upload.bin'
+    else:
+        body = payload if payload is not None else await request.body()
+        if not body:
+            raise HTTPException(status_code=400, detail='No file provided')
+        contents = body
+        original_name = request.headers.get('x-filename', 'upload.bin')
+
+    ext = os.path.splitext(original_name)[1] or '.bin'
     sid = str(uuid.uuid4()) + ext
     path = os.path.join(SAMPLES, sid)
     with open(path, 'wb') as f:
-        f.write(await file.read())
-    return {'id': sid, 'url': f'/samples/{sid}', 'name': file.filename}
+        f.write(contents)
+    return {'id': sid, 'url': f'/samples/{sid}', 'name': original_name}
+
+
+try:
+    import multipart  # type: ignore # noqa: F401
+    HAS_MULTIPART = True
+except ImportError:
+    try:
+        import python_multipart  # type: ignore # noqa: F401
+        HAS_MULTIPART = True
+    except ImportError:
+        HAS_MULTIPART = False
+
+
+if HAS_MULTIPART:
+    from fastapi import File
+
+    @app.post('/samples/upload')
+    async def upload_sample(
+        request: Request,
+        file: UploadFile | None = File(None),
+        payload: bytes | None = Body(default=None),
+    ):
+        return await _process_upload(request, file, payload)
+else:
+
+    @app.post('/samples/upload')
+    async def upload_sample(request: Request, payload: bytes | None = Body(default=None)):
+        return await _process_upload(request, None, payload)
 
 @app.get('/samples/list')
 def list_samples():
@@ -52,7 +93,7 @@ def list_samples():
 async def save_project(p: Project):
     pid = p.id or str(uuid.uuid4())
     with open(os.path.join(PROJECTS, pid + '.json'), 'w', encoding='utf-8') as f:
-        f.write(p.json())
+        f.write(p.model_dump_json())
     return {'id': pid}
 
 @app.get('/projects/{pid}')
@@ -62,3 +103,144 @@ def load_project(pid: str):
         return {'error': 'not found'}
     with open(path, 'r', encoding='utf-8') as f:
         return json.load(f)
+
+
+def _load_wav_sample(path: str):
+    with wave.open(path, 'rb') as wav_file:
+        channels = wav_file.getnchannels()
+        sample_width = wav_file.getsampwidth()
+        if channels != 1:
+            raise ValueError('Only mono WAV samples are supported')
+        if sample_width != 2:
+            raise ValueError('Only 16-bit PCM WAV samples are supported')
+        sample_rate = wav_file.getframerate()
+        frames = wav_file.readframes(wav_file.getnframes())
+    data = array('h')
+    data.frombytes(frames)
+    return sample_rate, data
+
+
+def render_loop_to_wav(project: dict, pid: str, cycles: int) -> str:
+    if cycles < 1:
+        raise ValueError('cycles must be at least 1')
+
+    transport = project.get('transport') or {}
+    bpm = float(transport.get('bpm', 120) or 120)
+    steps_per_bar = int(transport.get('stepsPerBar', 16) or 16)
+    if bpm <= 0:
+        raise ValueError('BPM must be positive')
+    if steps_per_bar <= 0:
+        raise ValueError('stepsPerBar must be positive')
+
+    pattern = project.get('pattern') or {}
+    pattern_length = int(pattern.get('length') or steps_per_bar)
+    if pattern_length <= 0:
+        raise ValueError('pattern length must be positive')
+
+    pads = {pad.get('id'): pad for pad in project.get('pads', []) if pad.get('id')}
+    step_map = {}
+    for key, pad_ids in (pattern.get('steps') or {}).items():
+        try:
+            idx = int(key)
+        except (TypeError, ValueError):
+            continue
+        step_map[idx] = list(pad_ids or [])
+
+    sample_cache = {}
+    sample_rate = None
+    for pad_id, pad in pads.items():
+        if pad.get('muted'):
+            continue
+        sample_meta = pad.get('sample')
+        if not sample_meta:
+            continue
+        sample_id = sample_meta.get('id')
+        if not sample_id:
+            continue
+        sample_path = os.path.join(SAMPLES, sample_id)
+        if not os.path.exists(sample_path):
+            raise ValueError(f'sample {sample_id} not found for pad {pad_id}')
+        rate, data = _load_wav_sample(sample_path)
+        if sample_rate is None:
+            sample_rate = rate
+        elif sample_rate != rate:
+            raise ValueError('all samples must share the same sample rate')
+        start_offset = max(0.0, float(pad.get('startOffset', 0.0) or 0.0))
+        offset_samples = int(round(start_offset * sample_rate))
+        if offset_samples >= len(data):
+            continue
+        trimmed = data[offset_samples:]
+        if not trimmed:
+            continue
+        gain = float(pad.get('gain', 1.0) or 0.0)
+        gain = max(0.0, min(gain, 1.0))
+        sample_cache[pad_id] = {'data': trimmed, 'gain': gain}
+
+    if not sample_cache:
+        raise ValueError('no samples available to export')
+
+    beats_per_sec = bpm / 60.0
+    step_factor = steps_per_bar / 4.0
+    if step_factor <= 0:
+        raise ValueError('stepsPerBar must be positive')
+    step_duration_sec = 1.0 / (beats_per_sec * step_factor)
+    step_samples = max(1, round(step_duration_sec * sample_rate))
+    total_steps = pattern_length * cycles
+    if total_steps <= 0:
+        raise ValueError('no steps to render')
+
+    mix_buffer = [0.0] * (step_samples * total_steps)
+
+    for cycle in range(cycles):
+        for step_index in range(pattern_length):
+            pad_ids = step_map.get(step_index, [])
+            if not pad_ids:
+                continue
+            start_pos = (cycle * pattern_length + step_index) * step_samples
+            for pad_id in pad_ids:
+                sample_info = sample_cache.get(pad_id)
+                if not sample_info:
+                    continue
+                data = sample_info['data']
+                gain = sample_info['gain']
+                end_pos = start_pos + len(data)
+                if end_pos > len(mix_buffer):
+                    mix_buffer.extend([0.0] * (end_pos - len(mix_buffer)))
+                for i, sample_val in enumerate(data):
+                    idx = start_pos + i
+                    if idx >= len(mix_buffer):
+                        break
+                    mix_buffer[idx] += (sample_val / 32768.0) * gain
+
+    output = array('h', [0] * len(mix_buffer))
+    for i, val in enumerate(mix_buffer):
+        if val > 1.0:
+            val = 1.0
+        elif val < -1.0:
+            val = -1.0
+        output[i] = int(round(val * 32767))
+
+    filename = f"{pid or 'project'}-loop-{cycles}x-{uuid.uuid4().hex}.wav"
+    out_path = os.path.join(EXPORTS, filename)
+    with wave.open(out_path, 'wb') as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(output.tobytes())
+
+    return out_path
+
+
+@app.get('/projects/{pid}/export')
+def export_project(pid: str, cycles: int = 1):
+    path = os.path.join(PROJECTS, pid + '.json')
+    if not os.path.exists(path):
+        raise HTTPException(status_code=404, detail='project not found')
+    with open(path, 'r', encoding='utf-8') as f:
+        project = json.load(f)
+    try:
+        export_path = render_loop_to_wav(project, pid, cycles)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    filename = os.path.basename(export_path)
+    return FileResponse(export_path, media_type='audio/wav', filename=filename)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,7 +5,9 @@ description = "Untitled Sampler Machine backend"
 requires-python = ">=3.10"
 dependencies = [
   "fastapi>=0.111.0",
-  "uvicorn[standard]>=0.30.0"
+  "uvicorn[standard]>=0.30.0",
+  "python-multipart>=0.0.9",
+  "pytest>=8.3.0"
 ]
 
 [tool.uvicorn]

--- a/backend/tests/test_loop_export.py
+++ b/backend/tests/test_loop_export.py
@@ -1,0 +1,151 @@
+import io
+import math
+import os
+import wave
+from array import array
+from importlib import reload
+
+import pytest
+from starlette.requests import Request
+
+
+def _make_test_tone(duration: float = 0.1, sample_rate: int = 44100, freq: float = 220.0):
+    total_samples = int(duration * sample_rate)
+    tone = array(
+        'h',
+        [
+            int(0.6 * 32767 * math.sin(2 * math.pi * freq * n / sample_rate))
+            for n in range(total_samples)
+        ],
+    )
+    buffer = io.BytesIO()
+    with wave.open(buffer, 'wb') as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(tone.tobytes())
+    buffer.seek(0)
+    return buffer, total_samples, sample_rate
+
+
+def _segment_has_audio(data: array, start: int, length: int) -> bool:
+    segment = data[start : start + length]
+    return any(abs(sample) > 0 for sample in segment)
+
+
+def _make_request(filename: str) -> Request:
+    async def receive():
+        return {'type': 'http.request', 'body': b'', 'more_body': False}
+
+    headers = [(b'x-filename', filename.encode())]
+    scope = {
+        'type': 'http',
+        'http_version': '1.1',
+        'method': 'POST',
+        'path': '/samples/upload',
+        'raw_path': b'/samples/upload',
+        'query_string': b'',
+        'headers': headers,
+        'client': ('testclient', 123),
+        'server': ('testserver', 80),
+    }
+    return Request(scope, receive)
+
+
+@pytest.fixture()
+def backend_app(tmp_path, monkeypatch):
+    storage_dir = tmp_path / 'storage'
+    monkeypatch.setenv('USM_STORAGE_DIR', str(storage_dir))
+    import backend.main as main_module
+
+    main = reload(main_module)
+    return main
+
+
+@pytest.fixture()
+def anyio_backend():
+    return 'asyncio'
+
+
+@pytest.mark.anyio()
+async def test_upload_loop_and_export(backend_app):
+    main = backend_app
+    sample_buffer, sample_frames, sample_rate = _make_test_tone()
+
+    request = _make_request('test-tone.wav')
+    upload_result = await main.upload_sample(request, payload=sample_buffer.getvalue())
+    sample_id = upload_result['id']
+
+    project_payload = {
+        'id': '',
+        'name': 'Loop Export Test',
+        'pads': [
+            {
+                'id': 'pad-0',
+                'name': 'Pad 1',
+                'color': '#ffffff',
+                'gain': 1.0,
+                'attack': 0.0,
+                'decay': 0.1,
+                'startOffset': 0.0,
+                'loop': False,
+                'muted': False,
+                'sample': {
+                    'id': sample_id,
+                    'name': 'test-tone.wav',
+                    'duration': sample_frames / sample_rate,
+                    'sampleRate': sample_rate,
+                },
+            }
+        ],
+        'pattern': {
+            'steps': {0: ['pad-0'], 8: ['pad-0']},
+            'length': 16,
+        },
+        'transport': {
+            'playing': False,
+            'bpm': 120,
+            'stepsPerBar': 16,
+            'bars': 1,
+            'swing': 0,
+        },
+    }
+
+    project_model = main.Project(**project_payload)
+    save_result = await main.save_project(project_model)
+    project_id = save_result['id']
+
+    cycles = 2
+    export_response = main.export_project(project_id, cycles=cycles)
+    assert export_response.media_type == 'audio/wav'
+    export_path = export_response.path
+    assert os.path.exists(export_path)
+
+    with wave.open(export_path, 'rb') as wav_file:
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getsampwidth() == 2
+        assert wav_file.getframerate() == sample_rate
+        frame_count = wav_file.getnframes()
+        frames = wav_file.readframes(frame_count)
+
+    audio_data = array('h')
+    audio_data.frombytes(frames)
+
+    beats_per_sec = project_payload['transport']['bpm'] / 60.0
+    step_factor = project_payload['transport']['stepsPerBar'] / 4.0
+    step_samples = round((1.0 / (beats_per_sec * step_factor)) * sample_rate)
+    expected_frames = step_samples * project_payload['pattern']['length'] * cycles
+    assert frame_count == expected_frames
+    assert max(abs(sample) for sample in audio_data) > 0
+
+    first_start = 0
+    second_start = step_samples * 8
+    third_start = step_samples * 16
+    fourth_start = step_samples * 24
+    assert _segment_has_audio(audio_data, first_start, sample_frames)
+    assert _segment_has_audio(audio_data, second_start, sample_frames)
+    assert _segment_has_audio(audio_data, third_start, sample_frames)
+    assert _segment_has_audio(audio_data, fourth_start, sample_frames)
+
+    exports = os.listdir(main.EXPORTS)
+    assert exports, 'an exported wav file should be written to disk'


### PR DESCRIPTION
## Summary
- add an environment-aware sample upload handler and WAV rendering helper
- expose a project loop export endpoint that mixes samples into a downloadable file
- cover the upload, sequencing, and export workflow with a new pytest

## Testing
- pytest backend/tests/test_loop_export.py

------
https://chatgpt.com/codex/tasks/task_e_68cbe3347930832cbed14ff23adc82a2