### PR TITLE
Handle multi-bar scheduling and document contributor guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Agent Guidelines
+
+## Required checks
+- Run `npm run build` from the `frontend` directory before finishing any task.
+- Run `npm run test` from the `frontend` directory when frontend code is touched.
+
+## Code style notes
+- Keep scheduler-related logic aware of the full pattern length (bars × steps).
+- Prefer sharing decoded audio data through the buffer store instead of globals.
+- Use the shared TypeScript types from `shared/` when exchanging data between layers.
+
+## Ideas to explore later
+- Persist decoded buffers alongside project data so sessions reload faster.
+- Add buffer registration to the sample recorder so recorded clips can play immediately.
+- Investigate swing and per-step velocity support in the scheduler.

--- a/frontend/src/audio/BufferStore.ts
+++ b/frontend/src/audio/BufferStore.ts
@@ -1,0 +1,23 @@
+const buffers: Record<string, AudioBuffer> = {}
+
+export function setBuffer(id: string, buffer: AudioBuffer) {
+  buffers[id] = buffer
+}
+
+export function getBuffer(id: string) {
+  return buffers[id]
+}
+
+export function hasBuffer(id: string) {
+  return id in buffers
+}
+
+export function clearBuffer(id: string) {
+  delete buffers[id]
+}
+
+export function getAllBuffers() {
+  return buffers
+}
+
+export type BufferStore = Record<string, AudioBuffer>

--- a/frontend/src/audio/Scheduler.ts
+++ b/frontend/src/audio/Scheduler.ts
@@ -1,14 +1,18 @@
 // Basic look-ahead scheduler
 import { engine } from './Engine'
-type Callback = (when:number, step:number)=>void
+
+type Callback = (when: number, stepInBar: number, absoluteStep: number) => void
 
 export class Scheduler {
   tempo = 120
   stepsPerBar = 16
+  bars = 1
   lookahead = 0.025 // seconds
   scheduleHorizon = 0.10 // seconds
   private nextTime = 0
-  private currentStep = 0
+  private stepInBar = 0
+  private stepIndex = 0
+  private totalSteps = this.stepsPerBar * this.bars
   private rafId: number | null = null
   private cb: Callback
 
@@ -16,9 +20,13 @@ export class Scheduler {
     this.cb = cb
   }
 
-  set(tempo:number, stepsPerBar:number) {
+  set(tempo:number, stepsPerBar:number, bars = 1) {
     this.tempo = tempo
     this.stepsPerBar = stepsPerBar
+    this.bars = bars
+    this.totalSteps = Math.max(1, this.stepsPerBar * this.bars)
+    this.stepIndex = this.stepIndex % this.totalSteps
+    this.stepInBar = this.stepIndex % this.stepsPerBar
   }
 
   private stepDurationSec() {
@@ -29,12 +37,15 @@ export class Scheduler {
 
   start() {
     this.nextTime = engine.ctx.currentTime + 0.06
+    this.stepIndex = 0
+    this.stepInBar = 0
     const tick = () => {
       const now = engine.ctx.currentTime
       while (this.nextTime < now + this.scheduleHorizon) {
-        this.cb(this.nextTime, this.currentStep)
+        this.cb(this.nextTime, this.stepInBar, this.stepIndex)
         this.nextTime += this.stepDurationSec()
-        this.currentStep = (this.currentStep + 1) % this.stepsPerBar
+        this.stepIndex = (this.stepIndex + 1) % this.totalSteps
+        this.stepInBar = this.stepIndex % this.stepsPerBar
       }
       this.rafId = requestAnimationFrame(tick)
     }
@@ -44,5 +55,7 @@ export class Scheduler {
   stop() {
     if (this.rafId) cancelAnimationFrame(this.rafId)
     this.rafId = null
+    this.stepIndex = 0
+    this.stepInBar = 0
   }
 }

--- a/frontend/src/components/Transport.test.tsx
+++ b/frontend/src/components/Transport.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { TransportBar } from './Transport';
 import { useStore } from '../store';
-import { vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../store');
 
@@ -10,8 +10,8 @@ describe('TransportBar', () => {
   const setBars = vi.fn();
 
   const mockState = {
-    transport: { playing: false, bpm: 120, bars: 4 },
-    pattern: { steps: [] },
+    transport: { playing: false, bpm: 120, bars: 4, stepsPerBar: 16, swing: 0 },
+    pattern: { steps: {} },
     pads: [],
     setTransport,
     setBars,


### PR DESCRIPTION
## Summary
- update the transport scheduler to track both the step within the bar and the absolute step so multi-bar patterns play back
- read absolute step events in the transport component and pass bar count into the scheduler configuration
- refresh the transport test fixtures with full transport data and add a repo-wide AGENTS.md for future contributors

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc15b0ed20832cb2057f671a7e7203