### PR TITLE
Fix sequencer step cell layout

### DIFF
--- a/frontend/src/components/Sequencer.tsx
+++ b/frontend/src/components/Sequencer.tsx
@@ -24,6 +24,7 @@ export function Sequencer() {
                   } ${isNow ? 'ring-2 ring-brand-secondary' : ''} ${
                     i % 4 === 0 ? 'border-l-2 border-gray-600' : ''
                   }`}
+                  style={{ height: '2rem' }}
                   onClick={() => toggleStep(i, p.id)}
                 />
               )


### PR DESCRIPTION
## Summary
- add an explicit height to sequencer step cells so they render visibly and can be clicked

## Testing
- npm test -- --watch=false
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5665854b8832c81bd4e0f5d0fd742