### PR TITLE
feat: redesign transport bar layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,18 +18,18 @@ export default function App() {
       <DemoProjectLoader />
       <AppSidebar />
       <SidebarInset>
-        <SiteHeader />
-        <div className="app p-4">
-          <div className="panel">
-            <TransportBar />
-            <hr style={{borderColor:'#1f242b', margin:'12px 0'}} />
-            <SampleRecorder />
-          </div>
-          <div className="panel">
-            <PadGrid />
-            <div style={{height:12}} />
-            <Sequencer />
-          </div>
+        <div className="flex min-h-svh flex-col">
+          <SiteHeader />
+          <main className="flex-1 space-y-4 p-4 pb-24">
+            <div className="panel space-y-6">
+              <SampleRecorder />
+            </div>
+            <div className="panel space-y-4">
+              <PadGrid />
+              <Sequencer />
+            </div>
+          </main>
+          <TransportBar />
         </div>
       </SidebarInset>
     </SidebarProvider>

--- a/frontend/src/components/Sequencer.tsx
+++ b/frontend/src/components/Sequencer.tsx
@@ -8,28 +8,32 @@ export function Sequencer() {
   return (
     <div className="space-y-2">
       {pads.map(p => (
-        <div key={p.id} className="flex items-center gap-4">
-          <div className="w-20 text-right text-sm" style={{ color: p.color }}>
+        <div
+          key={p.id}
+          className="grid items-center gap-1"
+          style={{ gridTemplateColumns: `6.5rem repeat(${steps.length}, minmax(0, 1fr))` }}
+        >
+          <div
+            className="flex h-8 items-center justify-end rounded-md border border-white/10 bg-white/5 px-3 text-sm font-medium backdrop-blur"
+            style={{ color: p.color }}
+          >
             {p.name}
           </div>
-          <div className="flex-1 grid grid-cols-16 gap-1">
-            {steps.map(i => {
-              const on = (pattern.steps[i] || []).includes(p.id)
-              const isNow = i === currentStep
-              return (
-                <div
-                  key={i}
-                  className={`h-8 rounded-md cursor-pointer transition-all duration-150 ${
-                    on ? 'bg-brand-primary shadow-neon-glow' : 'bg-gray-700'
-                  } ${isNow ? 'ring-2 ring-brand-secondary' : ''} ${
-                    i % 4 === 0 ? 'border-l-2 border-gray-600' : ''
-                  }`}
-                  style={{ height: '2rem' }}
-                  onClick={() => toggleStep(i, p.id)}
-                />
-              )
-            })}
-          </div>
+          {steps.map(i => {
+            const on = (pattern.steps[i] || []).includes(p.id)
+            const isNow = i === currentStep
+            return (
+              <div
+                key={i}
+                className={`h-8 rounded-md cursor-pointer transition-all duration-150 ${
+                  on ? 'bg-brand-primary shadow-neon-glow' : 'bg-gray-700'
+                } ${isNow ? 'ring-2 ring-brand-secondary' : ''} ${
+                  i % 4 === 0 ? 'border-l-2 border-gray-600' : ''
+                }`}
+                onClick={() => toggleStep(i, p.id)}
+              />
+            )
+          })}
         </div>
       ))}
     </div>

--- a/frontend/src/components/Transport.tsx
+++ b/frontend/src/components/Transport.tsx
@@ -7,7 +7,6 @@ import { playBuffer } from '../audio/SamplePlayer'
 import { getBuffer } from '../audio/BufferStore'
 import { Button } from '@/components/ui/button'
 import { Slider } from '@/components/ui/slider'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { createMidiBlob, decodeMidiPattern } from '@/lib/midi'
 import type { Transport as TransportState } from '@shared/types'
 
@@ -38,44 +37,49 @@ export function TransportBar() {
   }, [t.bpm, t.stepsPerBar, t.bars])
 
   return (
-    <Card className="bg-glass-black shadow-neon-glow">
-      <CardHeader>
-        <CardTitle className="text-white">Transport</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="flex flex-wrap items-center gap-4 text-white">
-          <Button
-            variant="outline"
-            className="w-24 bg-glass-white hover:bg-brand-primary hover:shadow-neon-glow"
-            onClick={async () => {
-              await engine.resume()
-              if (t.playing) {
-                sched.stop()
-                setTransport({ playing: false })
-              } else {
-                sched.start()
-                setTransport({ playing: true })
-              }
-            }}
-          >
-            {t.playing ? <SquareStop className="mr-2" /> : <Play className="mr-2" />}
-            {t.playing ? 'Stop' : 'Play'}
-          </Button>
+    <nav className="sticky bottom-4 z-50 w-full px-4">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 rounded-2xl border border-white/20 bg-gradient-to-br from-white/20 via-white/10 to-white/5 px-6 py-4 text-white shadow-neon-glow backdrop-blur-xl">
+        <div className="flex flex-wrap items-center gap-4 md:flex-1">
+          <div className="flex items-center gap-4">
+            <div className="flex flex-col leading-tight">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.5em] text-brand-light/80">Transport</span>
+              <span className="text-sm font-medium text-brand-light">Control Center</span>
+            </div>
+            <Button
+              variant="outline"
+              className="h-12 rounded-xl border-brand-primary/60 bg-brand-primary/20 px-6 font-semibold text-brand-light transition-all duration-200 hover:-translate-y-0.5 hover:bg-brand-primary/40 hover:text-white hover:shadow-neon-glow"
+              onClick={async () => {
+                await engine.resume()
+                if (t.playing) {
+                  sched.stop()
+                  setTransport({ playing: false })
+                } else {
+                  sched.start()
+                  setTransport({ playing: true })
+                }
+              }}
+            >
+              {t.playing ? <SquareStop className="h-5 w-5" /> : <Play className="h-5 w-5" />}
+              <span>{t.playing ? 'Stop' : 'Play'}</span>
+            </Button>
+          </div>
 
-          <div className="flex items-center gap-2">
-            <label className="text-sm">BPM</label>
+          <div className="flex items-center gap-3 text-sm">
+            <label className="text-[10px] uppercase tracking-[0.4em] text-brand-light/80">BPM</label>
             <Slider
               min={60}
               max={200}
               value={[t.bpm]}
               onValueChange={([val]) => setTransport({ bpm: val })}
-              className="w-32"
+              className="w-40"
             />
-            <span className="w-8 text-center">{t.bpm}</span>
+            <span className="min-w-[3rem] rounded-lg border border-white/20 bg-white/10 px-2 py-1 text-center text-sm font-semibold text-brand-light">
+              {t.bpm}
+            </span>
           </div>
 
-          <div className="flex items-center gap-2">
-            <label className="text-sm">Bars</label>
+          <div className="flex items-center gap-3 text-sm">
+            <label className="text-[10px] uppercase tracking-[0.4em] text-brand-light/80">Bars</label>
             <BarsControl />
           </div>
 
@@ -83,8 +87,8 @@ export function TransportBar() {
             <MidiControls />
           </div>
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </nav>
   )
 }
 
@@ -93,11 +97,23 @@ function BarsControl() {
   const setBars = useStore(s => s.setBars)
   return (
     <div className="flex items-center gap-2">
-      <Button size="icon" variant="outline" onClick={() => setBars(Math.max(1, bars - 1))}>
+      <Button
+        size="icon"
+        variant="outline"
+        className="h-11 w-11 rounded-xl border-white/30 bg-white/10 text-white transition-all duration-200 hover:-translate-y-0.5 hover:bg-brand-primary/40 hover:text-white hover:shadow-neon-glow"
+        onClick={() => setBars(Math.max(1, bars - 1))}
+      >
         <Minus />
       </Button>
-      <span className="w-6 text-center">{bars}</span>
-      <Button size="icon" variant="outline" onClick={() => setBars(Math.min(8, bars + 1))}>
+      <span className="min-w-[2.5rem] rounded-lg border border-white/20 bg-white/10 px-2 py-1 text-center text-sm font-semibold text-brand-light">
+        {bars}
+      </span>
+      <Button
+        size="icon"
+        variant="outline"
+        className="h-11 w-11 rounded-xl border-white/30 bg-white/10 text-white transition-all duration-200 hover:-translate-y-0.5 hover:bg-brand-primary/40 hover:text-white hover:shadow-neon-glow"
+        onClick={() => setBars(Math.min(8, bars + 1))}
+      >
         <Plus />
       </Button>
     </div>
@@ -165,12 +181,19 @@ function MidiControls() {
         className="hidden"
         onChange={onFileChange}
       />
-      <Button variant="outline" size="icon" onClick={handleExport} title="Export MIDI">
+      <Button
+        variant="outline"
+        size="icon"
+        className="h-11 w-11 rounded-xl border-white/30 bg-white/10 text-white transition-all duration-200 hover:-translate-y-0.5 hover:bg-brand-primary/40 hover:text-white hover:shadow-neon-glow"
+        onClick={handleExport}
+        title="Export MIDI"
+      >
         <Download className="h-4 w-4" />
       </Button>
       <Button
         variant="outline"
         size="icon"
+        className="h-11 w-11 rounded-xl border-white/30 bg-white/10 text-white transition-all duration-200 hover:-translate-y-0.5 hover:bg-brand-primary/40 hover:text-white hover:shadow-neon-glow"
         onClick={() => fileInputRef.current?.click()}
         title="Import MIDI"
       >


### PR DESCRIPTION
## Summary
- move the transport controls into a sticky footer navigation bar with a glassmorphism treatment
- rebalance the main layout so the sampler panels sit above the new transport bar and keep consistent spacing
- align sequencer pad labels within a fixed grid so names line up with the step columns

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5affcfdb8832ca2601ea7c596ea09