### PR TITLE
Enhance recording workflow and sequencer grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ and hear a beat immediately.
 
 ### Recording straight into pads
 - The sample recorder component (`SampleRecorder.tsx`) captures microphone input
-  with the MediaRecorder API and assigns the result to the currently selected pad.
+  with the MediaRecorder API and now includes a real-time level meter so you can
+  gauge headroom while tracking.
+- After stopping, you can audition the captured waveform, trim start/end points
+  with a twin-handle slider and explicitly assign the clip to any pad before it
+  lands in the project state.
 - Recordings are stored client‑side by default, but the wiring is ready for you
   to post the blob to the backend for persistence or conversion.
 
@@ -121,6 +125,11 @@ The demo assets are small synthetic 808-inspired one-shots generated entirely in
 the browser on first render. They are lightweight enough for rapid prototyping,
 but feel free to replace them with your own recordings.
 
+## Progress Report
+
+- 2025-10-08T17:22:24Z — Added a live input meter and trim workflow to the
+  recorder, plus step toggles that react immediately in the sequencer grid.
+
 ## Testing
 
 Both the backend and frontend ship with focused tests that exercise their core
@@ -162,3 +171,5 @@ behaviour.
 ## Notes
 - This is scaffolding; not production hardened. Replace stubs and expand to taste.
 - Worklet processor is stubbed; you can migrate envelopes to an AudioWorklet if needed.
+- Future innovation idea: create a user database and companion document library
+  so players can organise, re-use and save personally collected sounds across sessions.

--- a/frontend/src/components/PadPropertiesPanel.tsx
+++ b/frontend/src/components/PadPropertiesPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useStore } from '../store'
 import { getBuffer } from '../audio/BufferStore'
+import { computePeaks } from '@/lib/audioAnalysis'
 import type {
   EqualizerBand,
   Pad,
@@ -150,30 +151,7 @@ export function PadPropertiesPanel() {
       setPeaks([])
       return
     }
-    const resolution = 256
-    const bucketSize = Math.max(1, Math.floor(buffer.length / resolution))
-    const channels = Array.from({ length: buffer.numberOfChannels }, (_, i) =>
-      buffer.getChannelData(i)
-    )
-    const values: number[] = []
-    for (let bucket = 0; bucket < resolution; bucket += 1) {
-      const start = bucket * bucketSize
-      const end = Math.min(start + bucketSize, buffer.length)
-      if (start >= end) {
-        values.push(0)
-        continue
-      }
-      let sum = 0
-      for (const channel of channels) {
-        for (let i = start; i < end; i += 1) {
-          sum += Math.abs(channel[i])
-        }
-      }
-      const count = (end - start) * channels.length
-      values.push(count ? sum / count : 0)
-    }
-    const max = values.reduce((acc, val) => (val > acc ? val : acc), 0)
-    setPeaks(max > 0 ? values.map(v => v / max) : values)
+    setPeaks(computePeaks(buffer))
   }, [selectedPad?.id, selectedPad?.sample?.id])
 
   if (!selectedPad) {

--- a/frontend/src/components/SampleRecorder.tsx
+++ b/frontend/src/components/SampleRecorder.tsx
@@ -1,33 +1,138 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { Mic, Square } from 'lucide-react'
+import { Check, Info, Mic, Play, RefreshCcw, Square } from 'lucide-react'
 import { useStore } from '../store'
 import { decodeArrayBuffer, playBuffer } from '../audio/SamplePlayer'
 import { setBuffer } from '../audio/BufferStore'
 import { engine } from '../audio/Engine'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Slider } from '@/components/ui/slider'
+import { computePeaks } from '@/lib/audioAnalysis'
+
+type PreviewSample = {
+  buffer: AudioBuffer
+  fileName: string
+  url: string
+}
+
+type StrictFloat32Array = Float32Array<ArrayBuffer>
 
 export function SampleRecorder() {
+  const pads = useStore(s => s.pads)
   const sel = useStore(s => s.selectedPadId)
   const setPad = useStore(s => s.setPad)
+  const setSelectedPad = useStore(s => s.setSelectedPad)
   const [recState, setRecState] = useState<'idle' | 'recording' | 'processing'>('idle')
   const mediaRec = useRef<MediaRecorder | null>(null)
   const chunks = useRef<Blob[]>([])
+  const streamRef = useRef<MediaStream | null>(null)
+  const analyserRef = useRef<AnalyserNode | null>(null)
+  const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null)
+  const levelData = useRef<StrictFloat32Array | null>(null)
+  const levelFrame = useRef<number>()
+
+  const [inputLevel, setInputLevel] = useState(0)
+  const [targetPadId, setTargetPadId] = useState<string | undefined>(sel)
+  const [preview, setPreview] = useState<PreviewSample | null>(null)
+  const [trimRange, setTrimRange] = useState<[number, number]>([0, 0])
+  const [peaks, setPeaks] = useState<number[]>([])
+  const [statusMessage, setStatusMessage] = useState<string>('')
+
+  useEffect(() => {
+    if (sel) {
+      setTargetPadId(sel)
+    }
+  }, [sel])
 
   useEffect(() => {
     return () => {
       if (mediaRec.current?.state === 'recording') mediaRec.current.stop()
+      stopMonitoring()
+      streamRef.current?.getTracks().forEach(track => track.stop())
     }
   }, [])
 
+  useEffect(() => {
+    return () => {
+      if (preview?.url) {
+        URL.revokeObjectURL(preview.url)
+      }
+    }
+  }, [preview?.url])
+
+  useEffect(() => {
+    if (preview?.buffer) {
+      const duration = preview.buffer.duration
+      setTrimRange([0, duration])
+      setPeaks(computePeaks(preview.buffer))
+    } else {
+      setTrimRange([0, 0])
+      setPeaks([])
+    }
+  }, [preview?.buffer])
+
+  const stopMonitoring = () => {
+    if (levelFrame.current) {
+      cancelAnimationFrame(levelFrame.current)
+      levelFrame.current = undefined
+    }
+    analyserRef.current?.disconnect()
+    analyserRef.current = null
+    sourceRef.current?.disconnect()
+    sourceRef.current = null
+    levelData.current = null
+    setInputLevel(0)
+  }
+
+  const handleLevelFrame = () => {
+    const analyser = analyserRef.current
+    if (!analyser || !levelData.current) return
+
+    analyser.getFloatTimeDomainData(levelData.current)
+    let sumSquares = 0
+    for (let i = 0; i < levelData.current.length; i += 1) {
+      const sample = levelData.current[i]
+      sumSquares += sample * sample
+    }
+    const rms = Math.sqrt(sumSquares / levelData.current.length)
+    setInputLevel(rms)
+    levelFrame.current = requestAnimationFrame(handleLevelFrame)
+  }
+
   const startRec = async () => {
-    if (!sel || recState !== 'idle') return
-    const padId = sel
+    if (recState !== 'idle') return
+    if (!targetPadId) {
+      setStatusMessage('Select a pad to assign the recording to before capturing audio.')
+      return
+    }
+
+    setStatusMessage('')
+    setPreview(null)
+    setPeaks([])
 
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    streamRef.current = stream
     const mr = new MediaRecorder(stream)
     mediaRec.current = mr
     chunks.current = []
+
+    await engine.resume()
+    const source = engine.ctx.createMediaStreamSource(stream)
+    const analyser = engine.ctx.createAnalyser()
+    analyser.fftSize = 2048
+    analyser.smoothingTimeConstant = 0.4
+    source.connect(analyser)
+    analyserRef.current = analyser
+    sourceRef.current = source
+    levelData.current = new Float32Array(new ArrayBuffer(analyser.fftSize * 4)) as StrictFloat32Array
+    levelFrame.current = requestAnimationFrame(handleLevelFrame)
 
     mr.ondataavailable = e => {
       if (e.data.size > 0) chunks.current.push(e.data)
@@ -43,38 +148,21 @@ export function SampleRecorder() {
       try {
         const arrayBuffer = await blob.arrayBuffer()
         const buffer = await decodeArrayBuffer(arrayBuffer)
-
-        // cache buffer + update store
-        setBuffer(padId, buffer)
-        setPad(padId, {
-          sample: {
-            id: padId,
-            name: file.name,
-            duration: buffer.duration,
-            sampleRate: buffer.sampleRate,
+        setPreview(prev => {
+          if (prev?.url) {
+            URL.revokeObjectURL(prev.url)
+          }
+          return {
+            buffer,
+            fileName: file.name,
             url,
-          },
-          trimStart: 0,
-          trimEnd: buffer.duration,
-          startOffset: 0,
+          }
         })
-
-        // auto audition
-        const pad = useStore.getState().pads.find(p => p.id === padId)
-        if (pad) {
-          await engine.resume()
-          playBuffer(buffer, engine.ctx.currentTime, {
-            gain: pad.gain,
-            attack: pad.attack,
-            decay: pad.decay,
-            startOffset: pad.startOffset,
-            endOffset: pad.trimEnd ?? undefined,
-            loop: pad.loop,
-          })
-        }
       } catch (err) {
         console.error('Failed to process recording', err)
+        setStatusMessage('Something went wrong while decoding the recording.')
       } finally {
+        stopMonitoring()
         stream.getTracks().forEach(track => track.stop())
         // only clear if this stop corresponds to the same recorder
         if (mediaRec.current === mr) {
@@ -92,41 +180,257 @@ export function SampleRecorder() {
     if (mediaRec.current?.state === 'recording') {
       mediaRec.current.stop()
     }
+    stopMonitoring()
   }
+
+  const assignToPad = async () => {
+    if (!preview || !targetPadId) {
+      setStatusMessage('Record audio first, then choose a destination pad to assign it to.')
+      return
+    }
+
+    setBuffer(targetPadId, preview.buffer)
+    setPad(targetPadId, {
+      sample: {
+        id: targetPadId,
+        name: preview.fileName,
+        duration: preview.buffer.duration,
+        sampleRate: preview.buffer.sampleRate,
+        url: preview.url,
+      },
+      trimStart: trimRange[0],
+      trimEnd: trimRange[1],
+      startOffset: trimRange[0],
+    })
+    setSelectedPad(targetPadId)
+
+    const pad = useStore.getState().pads.find(p => p.id === targetPadId)
+    await engine.resume()
+    playBuffer(preview.buffer, engine.ctx.currentTime, {
+      gain: pad?.gain ?? 1,
+      attack: pad?.attack ?? 0,
+      decay: pad?.decay ?? 0.25,
+      startOffset: trimRange[0],
+      endOffset: trimRange[1],
+      loop: pad?.loop ?? false,
+    })
+
+    setStatusMessage(`Assigned to ${pad?.name ?? targetPadId}.`)
+  }
+
+  const auditionRecording = async () => {
+    if (!preview) return
+    const pad = targetPadId
+      ? useStore.getState().pads.find(p => p.id === targetPadId)
+      : undefined
+    await engine.resume()
+    playBuffer(preview.buffer, engine.ctx.currentTime, {
+      gain: pad?.gain ?? 1,
+      attack: pad?.attack ?? 0,
+      decay: pad?.decay ?? 0.25,
+      startOffset: trimRange[0],
+      endOffset: trimRange[1],
+      loop: false,
+    })
+  }
+
+  const discardPreview = () => {
+    if (preview?.url) {
+      URL.revokeObjectURL(preview.url)
+    }
+    setPreview(null)
+    setTrimRange([0, 0])
+    setPeaks([])
+    setStatusMessage('Recording cleared.')
+  }
+
+  const levelPercent = Math.min(1, inputLevel * 3)
+  const trimDisabled = !preview || preview.buffer.duration <= 0
 
   return (
     <Card className="bg-glass-black shadow-neon-glow">
       <CardHeader>
         <CardTitle className="text-white">Record Sample</CardTitle>
       </CardHeader>
-      <CardContent className="flex items-center gap-4">
-        <Button
-          variant="outline"
-          onClick={startRec}
-          disabled={!sel || recState !== 'idle'}
-          className="bg-glass-white text-white hover:bg-red-500 hover:shadow-neon-glow"
-        >
-          <Mic className="mr-2" />
-          Record
-        </Button>
-        <Button
-          variant="outline"
-          onClick={stopRec}
-          disabled={recState !== 'recording'}
-          className="bg-glass-white text-white hover:bg-brand-primary hover:shadow-neon-glow"
-        >
-          <Square className="mr-2" />
-          Stop
-        </Button>
-        <div className="flex items-center gap-2 text-white">
-          {recState === 'recording' && (
-            <div className="w-3 h-3 rounded-full bg-red-500 animate-pulse" />
-          )}
-          <span className="text-sm">
-            {sel ? `Target: ${sel}` : 'Select a pad'}
-            {recState === 'processing' && ' (processing...)'}
-          </span>
+      <CardContent className="space-y-6">
+        <div className="flex flex-wrap items-center gap-4">
+          <Button
+            variant="outline"
+            onClick={startRec}
+            disabled={recState !== 'idle'}
+            className="bg-glass-white text-white hover:bg-red-500 hover:shadow-neon-glow"
+          >
+            <Mic className="mr-2" />
+            Record
+          </Button>
+          <Button
+            variant="outline"
+            onClick={stopRec}
+            disabled={recState !== 'recording'}
+            className="bg-glass-white text-white hover:bg-brand-primary hover:shadow-neon-glow"
+          >
+            <Square className="mr-2" />
+            Stop
+          </Button>
+          <Select
+            value={targetPadId}
+            onValueChange={value => {
+              setTargetPadId(value)
+              setSelectedPad(value)
+            }}
+          >
+            <SelectTrigger className="w-48 bg-black/40 text-left text-white">
+              <SelectValue placeholder="Assign to pad" />
+            </SelectTrigger>
+            <SelectContent className="bg-slate-900 text-white">
+              {pads.map(pad => (
+                <SelectItem key={pad.id} value={pad.id}>
+                  {pad.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div className="flex min-w-[180px] flex-1 flex-col gap-1 text-xs text-white/70">
+            <span className="uppercase tracking-[0.35em] text-brand-light/70">Input Level</span>
+            <div className="h-2 w-full overflow-hidden rounded-full bg-white/10">
+              <div
+                className="h-full rounded-full bg-gradient-to-r from-emerald-400 via-amber-300 to-rose-500 transition-all duration-150"
+                style={{ width: `${Math.round(levelPercent * 100)}%` }}
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-2 text-white">
+            {recState === 'recording' && (
+              <div className="h-3 w-3 animate-pulse rounded-full bg-red-500" />
+            )}
+            <span className="text-sm capitalize">{recState}</span>
+          </div>
         </div>
+
+        {preview && (
+          <div className="space-y-4 rounded-2xl border border-white/10 bg-white/5 p-4 text-white">
+            <div className="flex flex-wrap items-center justify-between gap-3 text-xs uppercase tracking-[0.35em] text-brand-light/70">
+              <span>Trim &amp; Review</span>
+              <span className="text-[11px] normal-case tracking-normal text-white/60">
+                {preview.fileName} · {(trimRange[1] - trimRange[0]).toFixed(2)}s of {preview.buffer.duration.toFixed(2)}s
+              </span>
+            </div>
+
+            <div className="relative h-28 w-full overflow-hidden rounded-xl border border-white/10 bg-black/40">
+              <svg
+                viewBox={`0 0 ${Math.max(peaks.length, 1)} 100`}
+                preserveAspectRatio="none"
+                className="absolute inset-0 h-full w-full text-brand-secondary/80"
+              >
+                {peaks.length > 0 ? (
+                  peaks.map((value, index) => {
+                    const height = value * 50
+                    const center = 50
+                    return (
+                      <rect
+                        key={index}
+                        x={index}
+                        y={center - height}
+                        width={1}
+                        height={height * 2}
+                        fill="currentColor"
+                        opacity={0.8}
+                      />
+                    )
+                  })
+                ) : (
+                  <text
+                    x="50%"
+                    y="50%"
+                    dominantBaseline="middle"
+                    textAnchor="middle"
+                    className="fill-white/40 text-xs"
+                  >
+                    Recording ready — adjust trim below
+                  </text>
+                )}
+              </svg>
+              <div
+                className="absolute inset-y-0 left-0 bg-black/70"
+                style={{ width: `${(trimRange[0] / (preview.buffer.duration || 1)) * 100}%` }}
+              />
+              <div
+                className="absolute inset-y-0 right-0 bg-black/70"
+                style={{
+                  width: `${Math.max(
+                    0,
+                    100 - (trimRange[1] / (preview.buffer.duration || 1)) * 100
+                  )}%`,
+                }}
+              />
+              <div
+                className="absolute inset-y-0 w-0.5 bg-brand-primary"
+                style={{ left: `${(trimRange[0] / (preview.buffer.duration || 1)) * 100}%` }}
+              />
+              <div
+                className="absolute inset-y-0 w-0.5 bg-brand-primary"
+                style={{ left: `${(trimRange[1] / (preview.buffer.duration || 1)) * 100}%` }}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-brand-light/70">
+                <span>Trim Window</span>
+                <span className="text-[11px] normal-case tracking-normal text-white/60">
+                  {trimRange[0].toFixed(2)}s – {trimRange[1].toFixed(2)}s
+                </span>
+              </div>
+              <Slider
+                min={0}
+                max={preview.buffer.duration > 0 ? preview.buffer.duration : 1}
+                step={0.005}
+                disabled={trimDisabled}
+                value={[trimRange[0], trimRange[1]]}
+                onValueChange={([start, end]) => {
+                  if (trimDisabled) return
+                  const duration = preview.buffer.duration
+                  const safeStart = Math.max(0, Math.min(start, Math.max(duration - 0.01, 0)))
+                  const safeEnd = Math.max(safeStart + 0.01, Math.min(end, duration))
+                  setTrimRange([safeStart, safeEnd])
+                }}
+              />
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                variant="outline"
+                className="bg-black/60 text-white hover:bg-brand-primary hover:shadow-neon-glow"
+                onClick={auditionRecording}
+              >
+                <Play className="mr-2 h-4 w-4" />
+                Audition Trim
+              </Button>
+              <Button
+                variant="outline"
+                className="bg-black/60 text-white hover:bg-emerald-500 hover:shadow-neon-glow"
+                onClick={assignToPad}
+              >
+                <Check className="mr-2 h-4 w-4" />
+                Assign to Pad
+              </Button>
+              <Button
+                variant="outline"
+                className="bg-black/60 text-white hover:bg-red-500/80 hover:shadow-neon-glow"
+                onClick={discardPreview}
+              >
+                <RefreshCcw className="mr-2 h-4 w-4" />
+                Discard
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {statusMessage && (
+          <div className="flex items-center gap-2 text-xs text-white/70">
+            <Info className="h-3.5 w-3.5 text-brand-secondary" />
+            <span>{statusMessage}</span>
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/frontend/src/components/Sequencer.tsx
+++ b/frontend/src/components/Sequencer.tsx
@@ -2,35 +2,41 @@ import React from 'react'
 import { useStore } from '../store'
 
 export function Sequencer() {
-  const { pattern, pads, currentStep, toggleStep } = useStore()
-  const steps = Array.from({ length: pattern.length }, (_, i) => i)
+  const pattern = useStore(s => s.pattern)
+  const pads = useStore(s => s.pads)
+  const currentStep = useStore(s => s.currentStep)
+  const toggleStep = useStore(s => s.toggleStep)
+  const steps = React.useMemo(() => Array.from({ length: pattern.length }, (_, i) => i), [pattern.length])
 
   return (
     <div className="space-y-2">
-      {pads.map(p => (
+      {pads.map(pad => (
         <div
-          key={p.id}
+          key={pad.id}
           className="grid items-center gap-1"
           style={{ gridTemplateColumns: `6.5rem repeat(${steps.length}, minmax(0, 1fr))` }}
         >
           <div
             className="flex h-8 items-center justify-end rounded-md border border-white/10 bg-white/5 px-3 text-sm font-medium backdrop-blur"
-            style={{ color: p.color }}
+            style={{ color: pad.color }}
           >
-            {p.name}
+            {pad.name}
           </div>
-          {steps.map(i => {
-            const on = (pattern.steps[i] || []).includes(p.id)
-            const isNow = i === currentStep
+          {steps.map(stepIndex => {
+            const activePads = pattern.steps[stepIndex] || []
+            const on = activePads.includes(pad.id)
+            const isNow = stepIndex === currentStep
             return (
-              <div
-                key={i}
-                className={`h-8 rounded-md cursor-pointer transition-all duration-150 ${
+              <button
+                key={stepIndex}
+                type="button"
+                aria-pressed={on}
+                className={`h-8 rounded-md transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-secondary ${
                   on ? 'bg-brand-primary shadow-neon-glow' : 'bg-gray-700'
                 } ${isNow ? 'ring-2 ring-brand-secondary' : ''} ${
-                  i % 4 === 0 ? 'border-l-2 border-gray-600' : ''
+                  stepIndex % 4 === 0 ? 'border-l-2 border-gray-600' : ''
                 }`}
-                onClick={() => toggleStep(i, p.id)}
+                onClick={() => toggleStep(stepIndex, pad.id)}
               />
             )
           })}

--- a/frontend/src/lib/audioAnalysis.ts
+++ b/frontend/src/lib/audioAnalysis.ts
@@ -1,0 +1,29 @@
+export function computePeaks(buffer: AudioBuffer, resolution = 256): number[] {
+  const bucketSize = Math.max(1, Math.floor(buffer.length / resolution))
+  const channels = Array.from({ length: buffer.numberOfChannels }, (_, i) =>
+    buffer.getChannelData(i)
+  )
+  const values: number[] = []
+
+  for (let bucket = 0; bucket < resolution; bucket += 1) {
+    const start = bucket * bucketSize
+    const end = Math.min(start + bucketSize, buffer.length)
+    if (start >= end) {
+      values.push(0)
+      continue
+    }
+
+    let sum = 0
+    for (const channel of channels) {
+      for (let i = start; i < end; i += 1) {
+        sum += Math.abs(channel[i])
+      }
+    }
+
+    const count = (end - start) * channels.length
+    values.push(count ? sum / count : 0)
+  }
+
+  const max = values.reduce((acc, val) => (val > acc ? val : acc), 0)
+  return max > 0 ? values.map(v => v / max) : values
+}


### PR DESCRIPTION
## Summary
- add a metered recording workflow with waveform trimming, pad assignment, and preview controls in the sample recorder UI
- extract reusable audio peak analysis for waveform previews and wire it into the pad properties panel
- improve sequencer step toggling reliability with button semantics and refresh the README with progress tracking and future roadmap notes

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e69d2349ac832c8399ad51ec58337b