### PR TITLE
Fix slider rendering so sampler property controls respond

### DIFF
--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -3,29 +3,41 @@ import * as SliderPrimitive from "@radix-ui/react-slider"
 
 import { cn } from "@/lib/utils"
 
+const TRACK_HEIGHT_PX = 6
+const THUMB_SIZE_PX = 14
+
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex w-full touch-none select-none items-center",
-      className
-    )}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
-    </SliderPrimitive.Track>
-    {(props.value || props.defaultValue)?.map((_, i) => (
-      <SliderPrimitive.Thumb
-        key={i}
-        className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
-      />
-    ))}
-  </SliderPrimitive.Root>
-))
+>(({ className, ...props }, ref) => {
+  const thumbCount =
+    props.value?.length ?? props.defaultValue?.length ?? 1
+
+  return (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn(
+        "relative flex w-full touch-none select-none items-center",
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        className="relative w-full grow overflow-hidden rounded-full bg-primary/20"
+        style={{ height: TRACK_HEIGHT_PX }}
+      >
+        <SliderPrimitive.Range className="absolute h-full bg-primary" />
+      </SliderPrimitive.Track>
+      {Array.from({ length: thumbCount }).map((_, i) => (
+        <SliderPrimitive.Thumb
+          key={i}
+          className="block rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+          style={{ width: THUMB_SIZE_PX, height: THUMB_SIZE_PX }}
+        />
+      ))}
+    </SliderPrimitive.Root>
+  )
+})
 Slider.displayName = SliderPrimitive.Root.displayName
 
 export { Slider }


### PR DESCRIPTION
## Summary
- set explicit pixel sizing on the shared slider component so the handles and track render at the expected dimensions
- compute the number of slider thumbs from the provided values to keep multi-handle controls working

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6f44243c4832ca8036ccda219b487