### PR TITLE
Replace bundled trim demo asset with generator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ The demo assets are small synthetic 808-inspired one-shots generated entirely in
 the browser on first render. They are lightweight enough for rapid prototyping,
 but feel free to replace them with your own recordings.
 
+## Included sample clip
+
+Need a quick file to exercise the trimming workflow or automated UI demos?
+Run `scripts/generate_trim_demo.py` to render a short sine wave directly into
+`frontend/public/trim-demo.wav` (or pass a custom path). The generated clip is
+lightweight, predictable and perfect for showing off start/end adjustments
+without hunting for external audio.
+
 ## Progress Report
 
 - 2025-10-08T17:22:24Z — Added a live input meter and trim workflow to the

--- a/scripts/generate_trim_demo.py
+++ b/scripts/generate_trim_demo.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Generate a short sine-wave clip for trimming demos without bundling binaries.
+
+The script writes a mono WAV file to the requested path (defaults to
+`frontend/public/trim-demo.wav`).
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import wave
+from pathlib import Path
+
+def render_sine(
+    *,
+    output: Path,
+    duration_seconds: float = 2.0,
+    frequency_hz: float = 440.0,
+    sample_rate: int = 48_000,
+    amplitude: float = 0.35,
+) -> None:
+    """Render a normalized sine tone to ``output``.
+
+    Args:
+        output: Destination path for the rendered WAV file.
+        duration_seconds: Clip length in seconds.
+        frequency_hz: Frequency of the generated sine tone.
+        sample_rate: Output sample rate in Hz.
+        amplitude: Peak amplitude (0.0-1.0) of the sine wave.
+    """
+    frame_count = int(duration_seconds * sample_rate)
+    with wave.open(str(output), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)  # 16-bit PCM
+        wav_file.setframerate(sample_rate)
+
+        for i in range(frame_count):
+            theta = 2.0 * math.pi * frequency_hz * (i / sample_rate)
+            sample = math.sin(theta) * amplitude
+            # Clamp and convert to signed 16-bit integer
+            clamped = max(-1.0, min(1.0, sample))
+            int_sample = int(clamped * 32767.0)
+            wav_file.writeframesraw(int_sample.to_bytes(2, byteorder="little", signed=True))
+
+        wav_file.writeframes(b"")
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "output",
+        nargs="?",
+        default="frontend/public/trim-demo.wav",
+        help="Path to write the generated WAV file (default: %(default)s)",
+    )
+    parser.add_argument("--duration", type=float, default=2.0, help="Clip length in seconds (default: %(default)s)")
+    parser.add_argument("--frequency", type=float, default=440.0, help="Sine frequency in Hz (default: %(default)s)")
+    parser.add_argument("--sample-rate", type=int, default=48_000, help="Sample rate in Hz (default: %(default)s)")
+    parser.add_argument(
+        "--amplitude",
+        type=float,
+        default=0.35,
+        help="Peak amplitude from 0.0-1.0 (default: %(default)s)",
+    )
+    return parser.parse_args()
+
+def main() -> None:
+    args = parse_args()
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    render_sine(
+        output=output_path,
+        duration_seconds=args.duration,
+        frequency_hz=args.frequency,
+        sample_rate=args.sample_rate,
+        amplitude=args.amplitude,
+    )
+    print(f"Wrote sine wave to {output_path}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- remove the committed trim-demo WAV asset so the repo no longer carries a binary
- add a Python helper that generates the trimming demo clip on demand
- document the helper in the README so demos still have an easy-to-find source file

## Testing
- npm run build
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e6ffbfd684832c94127a8ca5017cdd