### PR TITLE
Embed sample recorder within pad properties panel

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,6 @@ import { TransportBar } from "@/components/Transport"
 import { PadGrid } from "@/components/PadGrid"
 import { Sequencer } from "@/components/Sequencer"
 import { PadPropertiesPanel } from "@/components/PadPropertiesPanel"
-import { SampleRecorder } from "@/components/SampleRecorder"
 import { DemoProjectLoader } from "@/components/DemoProjectLoader"
 import {
   SidebarProvider,
@@ -22,9 +21,6 @@ export default function App() {
         <div className="flex min-h-svh flex-col">
           <SiteHeader />
           <main className="flex-1 space-y-4 p-4 pb-24">
-            <div className="panel space-y-6">
-              <SampleRecorder />
-            </div>
             <div className="panel space-y-4">
               <PadGrid />
               <Sequencer />

--- a/frontend/src/components/PadPropertiesPanel.tsx
+++ b/frontend/src/components/PadPropertiesPanel.tsx
@@ -18,6 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { SampleRecorder } from './SampleRecorder'
 
 const EQ_BANDS: { id: EqualizerBand; label: string }[] = [
   { id: '31', label: '31 Hz' },
@@ -260,6 +261,7 @@ export function PadPropertiesPanel() {
         )}
       </CardHeader>
       <CardContent className="space-y-6">
+        <SampleRecorder layout="embedded" activePadId={selectedPad.id} />
         <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
           <div className="space-y-4">
             <WaveformPreview


### PR DESCRIPTION
## Summary
- update the SampleRecorder component to support an embedded layout that automatically targets the active pad
- render the recorder inside the PadPropertiesPanel and remove the standalone recorder panel from the main layout
- preserve trimming, assignment, and status messaging within the compact panel section

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e8219f0434832ca61814f9d484d733