### PR TITLE
Reset PadGrid file input after loading and add regression test

### DIFF
--- a/frontend/src/components/PadGrid.test.tsx
+++ b/frontend/src/components/PadGrid.test.tsx
@@ -1,0 +1,98 @@
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import { PadGrid } from './PadGrid'
+import { useStore } from '../store'
+import { decodeArrayBuffer } from '../audio/SamplePlayer'
+import { setBuffer } from '../audio/BufferStore'
+
+vi.mock('../store', () => ({
+  useStore: vi.fn(),
+}))
+vi.mock('../audio/Engine', () => ({
+  engine: {
+    resume: vi.fn().mockResolvedValue(undefined),
+    ctx: { currentTime: 0 },
+  },
+}))
+
+vi.mock('../audio/SamplePlayer', () => ({
+  decodeArrayBuffer: vi.fn(() =>
+    Promise.resolve({
+      duration: 1.5,
+      sampleRate: 44100,
+    })
+  ),
+  playBuffer: vi.fn(),
+}))
+
+vi.mock('../audio/BufferStore', () => ({
+  getBuffer: vi.fn(),
+  setBuffer: vi.fn(),
+}))
+
+describe('PadGrid', () => {
+  let setPad: Mock
+  let setSelectedPad: Mock
+  const mockedUseStore = useStore as unknown as Mock
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedUseStore.mockReset()
+
+    setPad = vi.fn()
+    setSelectedPad = vi.fn()
+
+    const pads = [
+      {
+        id: 'pad-1',
+        name: 'Pad 1',
+        gain: 1,
+        attack: 0,
+        decay: 0,
+        startOffset: 0,
+        loop: false,
+        sample: undefined,
+      },
+    ]
+
+    mockedUseStore.mockImplementation(
+      (selector: (state: any) => any) =>
+        selector({
+          pads,
+          setPad,
+          selectedPadId: 'pad-1',
+          setSelectedPad,
+        })
+    )
+  })
+
+  it('loads the same file twice after resetting the input value', async () => {
+    globalThis.URL.createObjectURL = vi.fn()
+
+    const { container } = render(<PadGrid />)
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+
+    const mockFile = new File(['sample-data'], 'sound.wav', { type: 'audio/wav' })
+    const arrayBufferSpy = vi.fn(() => Promise.resolve(new ArrayBuffer(8)))
+    Object.defineProperty(mockFile, 'arrayBuffer', {
+      value: arrayBufferSpy,
+    })
+
+    fireEvent.change(input, { target: { files: [mockFile] } })
+    await waitFor(() => expect(setPad).toHaveBeenCalledTimes(1))
+
+    fireEvent.change(input, { target: { files: [mockFile] } })
+    await waitFor(() => expect(setPad).toHaveBeenCalledTimes(2))
+
+    expect(arrayBufferSpy).toHaveBeenCalledTimes(2)
+
+    const mockedDecodeArrayBuffer = decodeArrayBuffer as unknown as Mock
+    const mockedSetBuffer = setBuffer as unknown as Mock
+
+    expect(mockedDecodeArrayBuffer.mock.calls).toHaveLength(2)
+    expect(mockedSetBuffer.mock.calls).toHaveLength(2)
+  })
+})

--- a/frontend/src/components/PadGrid.tsx
+++ b/frontend/src/components/PadGrid.tsx
@@ -72,9 +72,13 @@ export function PadGrid() {
                     type="file"
                     accept="audio/*"
                     className="hidden"
-                    onChange={e => {
-                      const f = e.target.files?.[0]
-                      if (f) onLoad(p.id, f)
+                    onChange={async e => {
+                      const input = e.target as HTMLInputElement
+                      const f = input.files?.[0]
+                      if (f) {
+                        await onLoad(p.id, f)
+                        input.value = ''
+                      }
                     }}
                   />
                 </label>


### PR DESCRIPTION
## Summary
- reset the PadGrid file input value after a successful load so the same file can be reselected
- add a regression test that ensures the loader runs when the same file is chosen twice

## Testing
- npm run test -- --run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e849ab2c70832ca27a7b4d3f05dc4a