### PR TITLE
Fix transport current step for multi-bar playback

### DIFF
--- a/frontend/src/components/Transport.tsx
+++ b/frontend/src/components/Transport.tsx
@@ -11,7 +11,10 @@ import { createMidiBlob, decodeMidiPattern } from '@/lib/midi'
 import type { Transport as TransportState } from '@shared/types'
 
 const sched = new Scheduler((when, stepInBar, absoluteStep) => {
-  useStore.setState({ currentStep: stepInBar })
+  useStore.setState(state => {
+    const length = state.pattern.length || state.transport.stepsPerBar * state.transport.bars
+    return { currentStep: length > 0 ? absoluteStep % length : 0 }
+  })
   const { pattern, pads } = useStore.getState()
   const ids = pattern.steps[absoluteStep] || []
   ids.forEach(id => {


### PR DESCRIPTION
## Summary
- derive the transport `currentStep` from the absolute scheduler step based on the pattern length so multi-bar patterns advance correctly
- extend the transport unit test with scheduler/audio mocks to cover a two-bar pattern and verify playback still triggers pad buffers

## Testing
- npm run test -- --run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e8565cf13c832cbc086263dca820c2