### PR TITLE
Add doc for experimental GL/Three animation concepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Untitled Sampler Machine (USM)
 
+> [Experimental GL/Three animation concepts](docs/fiberGel.md)
+
 A minimal, extensible scaffold for a browser‑based drum/sampler workstation. The
 project ships with a working React client, a FastAPI backend, and a small set of
 shared types so you can focus on extending sampler behaviour instead of wiring

--- a/docs/fiberGel.md
+++ b/docs/fiberGel.md
@@ -1,0 +1,12 @@
+# Experimental GL/Three Animation Concepts
+
+## Ideas for experimental pad/button/panel animations
+
+1. **React-three-fiber pad surfaces** – Wrap each pad’s `<Card>` in `PadGrid` with a lightweight `Canvas` layer that renders a reactive plane or particle system. You can drive shader uniforms from the `selected` state (line 12) and pad color/sample metadata (lines 65-80) so idle pads shimmer gently, then burst when `onTrigger` fires (lines 15-27). Using GPU easing lets the double-click play action create volumetric ripples or audio-reactive displacement tied to gain/decay.
+
+2. **gl-transitions for sequencer buttons** – The sequencer’s per-step `<button>` already tracks `on` toggles and the live `currentStep` cursor (lines 25-37). Hook those values into a GLSL transition (e.g., wipe, ripple, CRT bloom) so each step morphs between inactive and active states instead of snapping colors. When `isNow` flips true, run a timed shader sweep across the row to visualize the transport head, blending neighboring steps with motion blur as the pattern advances.
+
+3. **Three-dimensional properties panel** – `PadPropertiesPanel` assembles waveform peaks, trim sliders, and pad metadata inside a glassy `<Card>` (lines 342-474). Swap the static gradient background for a `react-three-fiber` scene that extrudes the `peaks` data into a 3D waveform, lighting it with the pad color strip (lines 417-423). When users adjust trim or envelopes, animate the mesh morph in sync, and crossfade panel sections with gl-transitions so toggling loop/mute reveals futuristic HUD overlays rather than plain div swaps.
+
+## Testing
+⚠️ Tests not run (read-only QA review scope).


### PR DESCRIPTION
## Summary
- document experimental ideas for using gl-transitions and react-three-fiber in `docs/fiberGel.md`
- surface the new document from the README with a link near the top

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e87b5f6820832ca3840543e65e81f9