### PR TITLE
Fix pad visual rendering black screen

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@react-three/fiber": "^8.17.11",
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -37,6 +38,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
+        "three": "^0.164.1",
         "vaul": "^1.1.2",
         "zod": "^4.1.11",
         "zustand": "^4.5.4"
@@ -47,6 +49,7 @@
         "@testing-library/react": "^16.3.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "@types/three": "^0.180.0",
         "@vitejs/plugin-react": "^5.0.3",
         "autoprefixer": "^10.4.21",
         "jsdom": "^27.0.0",
@@ -561,6 +564,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
@@ -2058,6 +2068,81 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@react-three/fiber": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
+      "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.7",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^1.0.6",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.1.3",
+        "zustand": "^3.7.1"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=18 <19",
+        "react-dom": ">=18 <19",
+        "react-native": ">=0.64",
+        "three": ">=0.133"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.38",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.38.tgz",
@@ -2758,6 +2843,13 @@
         }
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -2902,14 +2994,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.25",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.25.tgz",
       "integrity": "sha512-oSVZmGtDPmRZtVDqvdKUi/qgCsWp5IDY29wp8na8Bj4B3cc99hfNzvNhlMkVVxctkAOGUA3Km7MMpBHAnWfcIA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2925,6 +3015,44 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+      "integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.0.4",
@@ -3062,6 +3190,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.65",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.65.tgz",
+      "integrity": "sha512-cYrHab4d6wuVvDW5tdsfI6/o6vcLMDe6w2Citd1oS51Xxu2ycLCnVo4fqwujfKWijrZMInTJIKcXxteoy21nVA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -3167,6 +3302,26 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.12",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.12.tgz",
@@ -3219,6 +3374,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/cac": {
@@ -3722,6 +3901,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -3838,6 +4024,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -3863,6 +4069,27 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -4257,6 +4484,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -4514,6 +4748,31 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4622,6 +4881,21 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/recharts": {
@@ -4848,6 +5122,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -4920,6 +5203,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/three": {
+      "version": "0.164.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.164.1.tgz",
+      "integrity": "sha512-iC/hUBbl1vzFny7f5GtqzVXYjMJKaTPxiCxXfrvVdBi1Sf+jhd1CAkitiFwC7mIBFCo3MrDLJG97yisoaWig0w==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@react-three/fiber": "^8.17.11",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -39,6 +40,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
+    "three": "^0.164.1",
     "vaul": "^1.1.2",
     "zod": "^4.1.11",
     "zustand": "^4.5.4"
@@ -49,6 +51,7 @@
     "@testing-library/react": "^16.3.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/three": "^0.180.0",
     "@vitejs/plugin-react": "^5.0.3",
     "autoprefixer": "^10.4.21",
     "jsdom": "^27.0.0",

--- a/frontend/src/components/PadGrid.test.tsx
+++ b/frontend/src/components/PadGrid.test.tsx
@@ -1,6 +1,8 @@
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Mock } from 'vitest'
+import type { Pad } from '@shared/types'
+
 import { PadGrid } from './PadGrid'
 import { useStore } from '../store'
 import { decodeArrayBuffer } from '../audio/SamplePlayer'
@@ -43,15 +45,39 @@ describe('PadGrid', () => {
     setPad = vi.fn()
     setSelectedPad = vi.fn()
 
-    const pads = [
+    const pads: Pad[] = [
       {
         id: 'pad-1',
         name: 'Pad 1',
+        color: '#ff00ff',
         gain: 1,
         attack: 0,
-        decay: 0,
+        decay: 0.4,
         startOffset: 0,
+        trimStart: 0,
+        trimEnd: null,
         loop: false,
+        muted: false,
+        reverbPreset: 'off',
+        reverbMix: 0,
+        noiseGate: {
+          enabled: false,
+          threshold: -60,
+          attack: 10,
+          release: 200,
+        },
+        eq: {
+          '31': 0,
+          '62': 0,
+          '125': 0,
+          '250': 0,
+          '500': 0,
+          '1k': 0,
+          '2k': 0,
+          '4k': 0,
+          '8k': 0,
+          '16k': 0,
+        },
         sample: undefined,
       },
     ]

--- a/frontend/src/components/PadVisual.tsx
+++ b/frontend/src/components/PadVisual.tsx
@@ -1,0 +1,206 @@
+import { Canvas, useFrame } from '@react-three/fiber'
+import type { RootState } from '@react-three/fiber'
+import { memo, useEffect, useMemo, useRef, useState } from 'react'
+import * as THREE from 'three'
+
+type PadVisualProps = {
+  color: string
+  gain: number
+  decay: number
+  isSelected: boolean
+  triggerSignal: number
+  sampleDuration?: number
+}
+
+type PadSurfaceUniforms = {
+  uTime: THREE.IUniform<number>
+  uColor: THREE.IUniform<THREE.Color>
+  uIntensity: THREE.IUniform<number>
+  uHighlight: THREE.IUniform<number>
+  uPulse: THREE.IUniform<number>
+}
+
+const vertexShader = /* glsl */ `
+  varying float vWave;
+  varying float vRadial;
+  varying float vIntensity;
+
+  uniform float uTime;
+  uniform float uIntensity;
+  uniform float uPulse;
+
+  void main() {
+    vec3 pos = position;
+    float wave = sin((pos.x + uTime * 0.7) * 3.6) + cos((pos.y - uTime * 1.1) * 3.2);
+    float radial = sin(length(pos.xy) * 7.5 - uTime * 3.6);
+    float pulse = exp(-length(pos.xy) * 2.8) * uPulse;
+    pos.z += (wave * 0.025 + radial * 0.045) * (0.5 + uIntensity * 0.9) + pulse * 0.15;
+    vWave = wave;
+    vRadial = radial;
+    vIntensity = uIntensity;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+  }
+`
+
+const fragmentShader = /* glsl */ `
+  varying float vWave;
+  varying float vRadial;
+  varying float vIntensity;
+
+  uniform vec3 uColor;
+  uniform float uHighlight;
+
+  void main() {
+    float shimmer = 0.55 + 0.45 * sin(vWave * 0.6 + vRadial * 0.8);
+    float glow = smoothstep(0.0, 1.2, vIntensity + 0.25);
+    vec3 base = mix(vec3(0.08, 0.09, 0.12), uColor, shimmer * 0.75);
+    vec3 highlight = mix(base, vec3(1.0), clamp(uHighlight, 0.0, 1.0) * 0.45);
+    float alpha = 0.55 + glow * 0.35;
+    gl_FragColor = vec4(highlight, alpha);
+  }
+`
+
+const PadSurface = memo(function PadSurface({ uniforms }: { uniforms: PadSurfaceUniforms }) {
+  return (
+    <mesh rotation-x={-Math.PI / 2}>
+      <planeGeometry args={[1.35, 1.35, 128, 128]} />
+      <shaderMaterial
+        uniforms={uniforms}
+        vertexShader={vertexShader}
+        fragmentShader={fragmentShader}
+        transparent
+        depthWrite={false}
+      />
+    </mesh>
+  )
+})
+
+const PadVisualCanvas = memo(function PadVisualCanvas({
+  color,
+  gain,
+  decay,
+  isSelected,
+  triggerSignal,
+  sampleDuration,
+}: PadVisualProps) {
+  const highlight = useRef(isSelected ? 1 : 0)
+  const highlightTarget = useRef(isSelected ? 1 : 0)
+  const intensity = useRef(0.35)
+  const pulse = useRef(0)
+
+  const uniforms = useRef<PadSurfaceUniforms>({
+    uTime: { value: 0 },
+    uColor: { value: new THREE.Color(color) },
+    uIntensity: { value: intensity.current },
+    uHighlight: { value: highlight.current },
+    uPulse: { value: pulse.current },
+  })
+
+  const speedBase = useMemo(() => {
+    const duration = sampleDuration ?? 0
+    const durationFactor = THREE.MathUtils.clamp(duration / 2.5, 0, 1)
+    const decayFactor = THREE.MathUtils.clamp(decay * 1.5, 0, 1.2)
+    return 1.1 + durationFactor * 0.9 + decayFactor * 0.6
+  }, [decay, sampleDuration])
+
+  useEffect(() => {
+    highlightTarget.current = isSelected ? 1 : 0
+  }, [isSelected])
+
+  useEffect(() => {
+    uniforms.current.uColor.value.set(color)
+  }, [color])
+
+  useEffect(() => {
+    pulse.current = 1.6
+  }, [triggerSignal])
+
+  useFrame((_state: RootState, delta: number) => {
+    const clampedDelta = Math.min(delta, 0.05)
+    pulse.current = Math.max(pulse.current - clampedDelta * (1.5 + decay * 0.6), 0)
+
+    const gainFactor = THREE.MathUtils.clamp(gain / 1.2, 0, 1.1)
+    const base = 0.2 + gainFactor * 0.45
+    const targetIntensity = base + highlight.current * 0.3 + pulse.current * 0.6
+    intensity.current += (targetIntensity - intensity.current) * Math.min(clampedDelta * 6, 1)
+
+    highlight.current += (highlightTarget.current - highlight.current) * Math.min(clampedDelta * 7.5, 1)
+
+    uniforms.current.uTime.value = (uniforms.current.uTime.value + clampedDelta * speedBase) % 1000
+    uniforms.current.uIntensity.value = intensity.current
+    uniforms.current.uHighlight.value = highlight.current
+    uniforms.current.uPulse.value = pulse.current
+  })
+
+  return (
+    <Canvas
+      className="absolute inset-0 h-full w-full pointer-events-none"
+      camera={{ position: [0, 1.4, 1.5], fov: 55 }}
+      gl={{ alpha: true, antialias: true }}
+      onCreated={(state: RootState) => {
+        state.gl.setClearColor(new THREE.Color('#000000'), 0)
+        state.gl.setClearAlpha(0)
+      }}
+      style={{ background: 'transparent' }}
+    >
+      <ambientLight intensity={0.45} />
+      <directionalLight position={[1.2, 1.8, 1.5]} intensity={0.6} color={color} />
+      <PadSurface uniforms={uniforms.current} />
+    </Canvas>
+  )
+})
+
+const PadVisualFallback = memo(function PadVisualFallback({
+  color,
+  isSelected,
+  triggerSignal,
+}: Pick<PadVisualProps, 'color' | 'isSelected' | 'triggerSignal'>) {
+  const [pulse, setPulse] = useState(0)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    setPulse(1)
+    const timeout = window.setTimeout(() => setPulse(0), 420)
+    return () => window.clearTimeout(timeout)
+  }, [triggerSignal])
+
+  const opacity = 0.48 + (isSelected ? 0.22 : 0) + pulse * 0.24
+
+  return (
+    <div
+      className="absolute inset-0 pointer-events-none transition duration-500 ease-out"
+      style={{
+        background: `radial-gradient(circle at 25% 25%, ${color}55, transparent 60%), radial-gradient(circle at 75% 75%, ${color}22, transparent 65%), linear-gradient(140deg, rgba(15,23,42,0.75), rgba(30,41,59,0.3))`,
+        opacity,
+        transform: `scale(${1 + pulse * 0.04})`,
+        filter: isSelected ? 'blur(0)' : 'blur(0.4px)',
+      }}
+    />
+  )
+})
+
+export const PadVisual = memo(function PadVisual(props: PadVisualProps) {
+  const supportsWebGL = useMemo(() => {
+    if (typeof document === 'undefined') return false
+    try {
+      const canvas = document.createElement('canvas')
+      const gl = canvas.getContext?.('webgl2') ?? canvas.getContext?.('webgl')
+      return Boolean(gl)
+    } catch (error) {
+      return false
+    }
+  }, [])
+
+  if (!supportsWebGL) {
+    const { color, isSelected, triggerSignal } = props
+    return (
+      <PadVisualFallback
+        color={color}
+        isSelected={isSelected}
+        triggerSignal={triggerSignal}
+      />
+    )
+  }
+
+  return <PadVisualCanvas {...props} />
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -138,3 +138,57 @@
     backdrop-filter: blur(4px);
   }
 }
+
+.pad-visual {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: 0.9rem;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.pad-visual__background,
+.pad-visual__shimmer,
+.pad-visual__grid,
+.pad-visual__glare {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+}
+
+.pad-visual__background {
+  transition: transform 220ms ease, box-shadow 260ms ease, opacity 220ms ease, border-color 260ms ease;
+  will-change: transform, opacity, box-shadow;
+}
+
+.pad-visual__shimmer {
+  opacity: 0.55;
+  mix-blend-mode: screen;
+  filter: blur(40px);
+  transform: scale(1.35);
+  animation-name: pad-visual-shimmer;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+.pad-visual__grid {
+  mix-blend-mode: screen;
+  opacity: 0.75;
+}
+
+.pad-visual__glare {
+  mix-blend-mode: screen;
+  background: radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.18), transparent 45%),
+    linear-gradient(120deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0) 45%);
+  opacity: 0.38;
+}
+
+@keyframes pad-visual-shimmer {
+  from {
+    transform: rotate(0deg) scale(1.35);
+  }
+  to {
+    transform: rotate(360deg) scale(1.35);
+  }
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,5 +1,10 @@
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
+vi.mock('@react-three/fiber', () => ({
+  __esModule: true,
+  Canvas: () => null,
+  useFrame: vi.fn(),
+}));
 
 Object.defineProperty(window, 'innerWidth', {
   writable: true,

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -65,3 +65,38 @@ class MockAudioContext {
 }
 
 (window as any).AudioContext = vi.fn().mockImplementation(() => new MockAudioContext());
+
+if (!HTMLCanvasElement.prototype.getContext) {
+  HTMLCanvasElement.prototype.getContext = vi.fn();
+}
+
+HTMLCanvasElement.prototype.getContext = vi
+  .fn()
+  .mockReturnValue({
+    fillRect: vi.fn(),
+    clearRect: vi.fn(),
+    getImageData: vi.fn(() => ({ data: new Uint8ClampedArray() })),
+    putImageData: vi.fn(),
+    createImageData: vi.fn(() => ({ data: new Uint8ClampedArray() })),
+    setTransform: vi.fn(),
+    drawImage: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    measureText: vi.fn(() => ({ width: 0 })),
+    createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+    translate: vi.fn(),
+    scale: vi.fn(),
+    rotate: vi.fn(),
+    rect: vi.fn(),
+  });
+
+HTMLCanvasElement.prototype.toDataURL = vi
+  .fn()
+  .mockReturnValue('data:image/png;base64,');

--- a/frontend/src/types/react-three-fiber.d.ts
+++ b/frontend/src/types/react-three-fiber.d.ts
@@ -1,0 +1,9 @@
+import type { ThreeElements } from '@react-three/fiber'
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements extends ThreeElements {}
+  }
+}
+
+export {}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+/// <reference types="vitest/globals" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,7 +11,6 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,
-    "types": ["vite/client", "vitest/globals"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,5 +16,6 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
+    testTimeout: 10000,
   },
 })


### PR DESCRIPTION
## Summary
- clear the react-three-fiber canvas to transparent so pad visuals no longer appear as a black screen
- type the render loop and state hook with RootState and add JSX intrinsic declarations for react-three-fiber
- restore vite/vitest ambient references via local d.ts files after removing the compiler `types` override

## Testing
- npm run build
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e87e73d7d4832cb178bf2ef3db9819