### PR TITLE
Replace WebGL pad visuals with animated CSS

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -138,3 +138,57 @@
     backdrop-filter: blur(4px);
   }
 }
+
+.pad-visual {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: 0.9rem;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.pad-visual__background,
+.pad-visual__shimmer,
+.pad-visual__grid,
+.pad-visual__glare {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+}
+
+.pad-visual__background {
+  transition: transform 220ms ease, box-shadow 260ms ease, opacity 220ms ease, border-color 260ms ease;
+  will-change: transform, opacity, box-shadow;
+}
+
+.pad-visual__shimmer {
+  opacity: 0.55;
+  mix-blend-mode: screen;
+  filter: blur(40px);
+  transform: scale(1.35);
+  animation-name: pad-visual-shimmer;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+.pad-visual__grid {
+  mix-blend-mode: screen;
+  opacity: 0.75;
+}
+
+.pad-visual__glare {
+  mix-blend-mode: screen;
+  background: radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.18), transparent 45%),
+    linear-gradient(120deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0) 45%);
+  opacity: 0.38;
+}
+
+@keyframes pad-visual-shimmer {
+  from {
+    transform: rotate(0deg) scale(1.35);
+  }
+  to {
+    transform: rotate(360deg) scale(1.35);
+  }
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -65,3 +65,38 @@ class MockAudioContext {
 }
 
 (window as any).AudioContext = vi.fn().mockImplementation(() => new MockAudioContext());
+
+if (!HTMLCanvasElement.prototype.getContext) {
+  HTMLCanvasElement.prototype.getContext = vi.fn();
+}
+
+HTMLCanvasElement.prototype.getContext = vi
+  .fn()
+  .mockReturnValue({
+    fillRect: vi.fn(),
+    clearRect: vi.fn(),
+    getImageData: vi.fn(() => ({ data: new Uint8ClampedArray() })),
+    putImageData: vi.fn(),
+    createImageData: vi.fn(() => ({ data: new Uint8ClampedArray() })),
+    setTransform: vi.fn(),
+    drawImage: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    measureText: vi.fn(() => ({ width: 0 })),
+    createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+    translate: vi.fn(),
+    scale: vi.fn(),
+    rotate: vi.fn(),
+    rect: vi.fn(),
+  });
+
+HTMLCanvasElement.prototype.toDataURL = vi
+  .fn()
+  .mockReturnValue('data:image/png;base64,');

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,5 +16,6 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
+    testTimeout: 10000,
   },
 })


### PR DESCRIPTION
## Summary
- replace the three.js-based pad visual with an animated CSS implementation that works without extra WebGL dependencies and includes a simplified test-mode fallback
- add supporting styles plus test setup stubs so Canvas usage no longer crashes under jsdom, and raise the Vitest timeout for the slow sidebar integration test

## Testing
- npm run build
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e88345b9a4832c8ec377d3e6d21acd