### PR TITLE
Add reactive WebGL pad surface with CSS fallback

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -157,6 +157,20 @@
   border-radius: inherit;
 }
 
+.pad-visual__canvas {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  filter: saturate(1.08);
+}
+
+.pad-visual__canvas canvas {
+  width: 100% !important;
+  height: 100% !important;
+  border-radius: inherit;
+}
+
 .pad-visual__background {
   transition: transform 220ms ease, box-shadow 260ms ease, opacity 220ms ease, border-color 260ms ease;
   will-change: transform, opacity, box-shadow;


### PR DESCRIPTION
## Summary
- layer a react-three-fiber Canvas over each pad to render a shader-driven surface that reacts to selection, sample data, and trigger pulses
- detect WebGL support at runtime so environments without WebGL continue to use the existing CSS glow treatment
- blend the Canvas overlay with new styles to keep the pad visuals consistent when the 3D surface is active

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e93dea9054832c830cb66c361fc08e