### PR TITLE
Add CSS fallbacks for GL-driven UI effects

### DIFF
--- a/frontend/src/hooks/useWebglSupport.ts
+++ b/frontend/src/hooks/useWebglSupport.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+
+function isTestEnvironment() {
+  try {
+    return typeof import.meta !== 'undefined' && import.meta.env?.MODE === 'test'
+  } catch {
+    return false
+  }
+}
+
+export function useWebglSupport(enabled: boolean) {
+  const [supported, setSupported] = useState(false)
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined' || isTestEnvironment()) {
+      setSupported(false)
+      return
+    }
+
+    let cancelled = false
+    let detected = false
+
+    try {
+      const canvas = document.createElement('canvas')
+      const context =
+        typeof canvas.getContext === 'function'
+          ? canvas.getContext('webgl') ?? canvas.getContext('experimental-webgl')
+          : null
+
+      if (context && typeof (context as WebGLRenderingContext).getExtension === 'function') {
+        detected = true
+        ;(context as WebGLRenderingContext).getExtension('WEBGL_lose_context')?.loseContext()
+      }
+    } catch {
+      detected = false
+    }
+
+    if (!cancelled) {
+      setSupported(detected)
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [enabled])
+
+  return enabled ? supported : false
+}
+


### PR DESCRIPTION
## Summary
- add a shared WebGL feature detection hook and reuse it in pad visuals
- provide CSS-driven sequencer step animations when WebGL or motion is unavailable
- render Pad Properties panel backgrounds and HUD toggles with CSS fallbacks whenever react-three-fiber cannot run

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e9451b8f98832cb271db6d5062c8c5